### PR TITLE
add S wave support to gen rayp lib

### DIFF
--- a/seispy/ccp/rayplib.py
+++ b/seispy/ccp/rayplib.py
@@ -1,0 +1,91 @@
+"""
+use obspy.taup instead of taup in java
+"""
+
+import numpy as np
+
+from obspy.taup import TauPyModel
+
+def rayp_input(phase_main:str,
+               source_dist_in_degree:str,
+               conver_layers:str,
+               source_depth_in_km:str,
+               out_put_path:str):
+    """
+    anaylize input informations
+    only allow P, SKS, S, ScS
+    """
+    if phase_main not in ['P', 'S', 'SKS', 'ScS']:
+        raise ValueError('not a valid phase')
+
+    try:
+        # set default step value for 2 input
+        source_dist_in_degree +='/1';source_dist_in_degree = [float(_i) for _i in source_dist_in_degree.split('/')[:4]]
+        conver_layers +='/1';conver_layers = [float(_i) for _i in conver_layers.split('/')[:4]]
+        source_depth_in_km +='/2';source_depth_in_km = [float(_i) for _i in source_depth_in_km.split('/')]
+        if conver_layers[0] < 0:
+            conver_layers[0] = 0
+        conver_layers = np.arange(conver_layers[0], conver_layers[1], conver_layers[2])
+        source_dist_in_degree = np.arange(source_dist_in_degree[0], source_dist_in_degree[1], source_dist_in_degree[2])
+        source_depth_in_km = np.arange(source_depth_in_km[0],source_depth_in_km[1], source_depth_in_km[2])
+    except:
+        raise ValueError('invalid inputs in dist and layers')
+    # here we limit layer_max to 30km
+    if conver_layers[-1] < 30:
+        raise ValueError('theres no need to do such a thing')
+
+
+    rayp = cal_taup('iasp91', phase_main,
+                    conver_layers, source_dist_in_degree, source_depth_in_km)
+
+    np.savez(out_put_path, dis = source_dist_in_degree, dep = source_depth_in_km, layers = conver_layers, rayp = rayp)
+
+
+
+
+def cal_taup(model:str, phase:str,
+             layer:np.ndarray, dist:np.ndarray, depth:np.ndarray):
+    """
+    cal rayp from obspy.taup
+    wont cal layers above 11km, change min_con
+
+    phase_list: list of phase names, like ["P30s", "P50s"]
+    layer : conversion layers
+    dist : numpy.ndarray, dist in deg
+    depth : numpy.ndarray, source_depth in km
+
+    """
+    min_con = 11
+    if phase[-1] == 'P':
+        conv = 's'
+    else:
+        conv = 'p'
+    ## init taup and matrix
+    rayp_lib = np.zeros((dist.shape[0], depth.shape[0], layer.shape[0]))
+    model = TauPyModel(model=model)
+    cal_layers_slice = np.where(layer > min_con); head = cal_layers_slice[0][0]
+    phase_list = ["{}{}{}".format(phase,_d, conv) for _d in layer[cal_layers_slice]]
+
+    ### main
+    for _i, _deg in enumerate(dist):
+        for _j, _dep in enumerate(depth):
+            print("now at degree {}, dep{}".format(_deg, _dep))
+            arrivals=model.get_travel_times(source_depth_in_km=_dep,
+                                            distance_in_degree=_deg,
+                                            phase_list=phase_list)
+            for _k in range(len(arrivals)):
+                # 101 for change rayp from s/deg to s/km
+                rayp_lib[_i,_j,head+_k] = arrivals[_k].ray_param_sec_degree
+    if head > 0:
+        for _layer in range(head):
+            rayp_lib[:,:,_layer] = rayp_lib[:,:,head]
+    return rayp_lib
+
+
+if __name__ == "__main__":
+    phase = "P"
+    dist = "30/50/1"
+    layers = "0/100/2"
+    depth = '0/100/5'
+    out_put = "G:/Ps_rayp.npz"
+    rayp_input("P", dist, layers, depth, out_put)

--- a/seispy/ccp/rayplib.py
+++ b/seispy/ccp/rayplib.py
@@ -69,13 +69,14 @@ def cal_taup(model:str, phase:str,
     ### main
     for _i, _deg in enumerate(dist):
         for _j, _dep in enumerate(depth):
-            print("now at degree {}, dep{}".format(_deg, _dep))
-            arrivals=model.get_travel_times(source_depth_in_km=_dep,
+            #print("now at degree {}, dep{}".format(_deg, _dep))
+            for _k, _phase in enumerate(phase_list):
+                arrivals=model.get_travel_times(source_depth_in_km=_dep,
                                             distance_in_degree=_deg,
-                                            phase_list=phase_list)
-            for _k in range(len(arrivals)):
-                # 101 for change rayp from s/deg to s/km
-                rayp_lib[_i,_j,head+_k] = arrivals[_k].ray_param_sec_degree
+                                            phase_list=[_phase])
+                if len(arrivals) == 0:
+                    continue
+                rayp_lib[_i,_j,head+_k] = arrivals[0].ray_param_sec_degree
     if head > 0:
         for _layer in range(head):
             rayp_lib[:,:,_layer] = rayp_lib[:,:,head]
@@ -83,9 +84,12 @@ def cal_taup(model:str, phase:str,
 
 
 if __name__ == "__main__":
-    phase = "P"
-    dist = "30/50/1"
+    # paras
+    phase = "S"
+    dist = "30/90/5"
     layers = "0/100/2"
     depth = '0/100/5'
     out_put = "G:/Ps_rayp.npz"
-    rayp_input("P", dist, layers, depth, out_put)
+
+    # run
+    rayp_input(phase, dist, layers, depth, out_put)


### PR DESCRIPTION
添加了对于其他类型震相的支持，包括S, ScS, SKS
使用了obspy.taup，计算速度可能会相对慢一些（没有测试）。考虑到的一些情况：

1. 射线路径不经过某一层，留空为0（三层循环体内最后一层的for）
2. 自己理解的fake_index（即太浅的界面直接跳过）。然后用最浅的一层补全。
3. 对参数的补全，line23-25的 +=''

文件的格式是大致一致的，面向命令行的接口待完成。

具体讨论下第一个问题的描述
![image](https://github.com/xumi1993/seispy/assets/81711503/131ac985-f899-4c3a-ae31-1c5780319149)
对比[obspy.taup 关于震相命名说明的第5项](https://docs.obspy.org/packages/obspy.taup.html)。即对于模型中没有的界面的转换波，TauP java toolkit 会返回最近界面上形成的转换波。

对于obspy.taup，似乎使用了不同的策略。对于模型上已有的界面，二者的结果一致，但对于45km这类在模型上没有的界面，二者的策略有所不同。
````python
>>> from obspy.taup import TauPyModel
>>> mod = TauPyModel(model = 'iasp91')
>>> arrivals_45 =  mod.get_travel_times(source_depth_in_km=45, distance_in_degree=55,phase_list=['S45.0p'])
>>> arrivals_35 =  mod.get_travel_times(source_depth_in_km=45, distance_in_degree=55,phase_list=['S35.0p'])
>>> print(arrivals_45)
2 arrivals
        S45.0p phase arrival at 1019.377 seconds
        S45.0p phase arrival at 1019.619 seconds
>>> print(arrivals_35)
1 arrivals
        S35p phase arrival at 1020.996 seconds
````
可见对于已有的界面，二者能给出相同的结果。但是对于在模型中没有体现的界面，obspy.taup给出的可能是一个插值的结果，这一点缺少对源码的解读。在PR里只使用第一个返回的结果。

即便这样，地壳尺度上1.5s的误差还是挺大的，尤其是考虑到SMohop 大都是S波到时前5s左右。

然后是里面丑陋至极的三重循环。这一点是因为多解，和计算结果并不按给出list的顺序返回。